### PR TITLE
Define Dockerfile distroless variant and cloud build example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-venv
+.venv

--- a/Dockerfile-distroless
+++ b/Dockerfile-distroless
@@ -1,0 +1,46 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# Build as
+# TODO(damondouglas): consider different directory with single Dockerfile or cloudbuild.yaml so that the command below uses gcloud builds.
+# docker buildx build -t <image URL> -f Dockerfile-distroless --build_arg=BASE=<template launcher image URL> .
+ARG BASE
+FROM ${BASE} AS base
+ENV LANG=C.UTF8
+
+FROM gcr.io/distroless/python3-debian12 AS final
+
+# Contains template code such as main.py.
+COPY --from=base /template /template
+
+# Prevents internal errors found with distroless container images and Flex templates.
+COPY --from=base /usr/lib/locale /usr/lib/locale
+
+# Contains header files needed by the Python interpreter.
+COPY --from=base /usr/local/include /usr/local/include
+
+# Contains the Python interpreter executables.
+COPY --from=base /usr/local/bin /usr/local/bin
+
+# Contains the Python library dependencies.
+COPY --from=base /usr/local/lib /usr/local/lib
+
+# Python standard library modules.
+COPY --from=base /usr/lib/python* /usr/lib/.
+
+# Contains additionally required files.
+COPY --from=base /opt /opt
+
+ENV PATH "$PATH:/usr/local/bin"
+
+ENTRYPOINT ["/opt/google/dataflow/python_template_launcher"]

--- a/Dockerfile-distroless
+++ b/Dockerfile-distroless
@@ -11,9 +11,6 @@
 # License for the specific language governing permissions and limitations under
 # the License.
 #
-# Build as
-# TODO(damondouglas): consider different directory with single Dockerfile or cloudbuild.yaml so that the command below uses gcloud builds.
-# docker buildx build -t <image URL> -f Dockerfile-distroless --build_arg=BASE=<template launcher image URL> .
 ARG BASE
 FROM ${BASE} AS base
 ENV LANG=C.UTF8
@@ -36,12 +33,12 @@ COPY --from=base /usr/local/bin /usr/local/bin
 COPY --from=base /usr/local/lib /usr/local/lib
 
 # Python standard library modules.
-COPY --from=base /usr/lib/python* /usr/lib/.
+COPY --from=base /usr/lib/python* /usr/lib/
 
 # Contains additionally required files.
 COPY --from=base /opt /opt
 
-# We have to reset the environment variables because we are using a new FROM image URL (I think?).
+# We have to reset the environment variables because we are using a new FROM image URL.
 ENV PATH "$PATH:/usr/local/bin"
 ENV FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE="/template/requirements.txt"
 ENV FLEX_TEMPLATE_PYTHON_PY_FILE="/template/main.py"

--- a/Dockerfile-distroless
+++ b/Dockerfile-distroless
@@ -41,6 +41,11 @@ COPY --from=base /usr/lib/python* /usr/lib/.
 # Contains additionally required files.
 COPY --from=base /opt /opt
 
+# We have to reset the environment variables because we are using a new FROM image URL (I think?).
 ENV PATH "$PATH:/usr/local/bin"
+ENV FLEX_TEMPLATE_PYTHON_REQUIREMENTS_FILE="/template/requirements.txt"
+ENV FLEX_TEMPLATE_PYTHON_PY_FILE="/template/main.py"
+ENV LD_LIBRARY_PATH /opt/oracle/instantclient_23_5
 
+# We have to reset the entrypoint due to using a new FROM image URL.
 ENTRYPOINT ["/opt/google/dataflow/python_template_launcher"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+substitutions:
+  # assumes Artifact Registry created via:
+  # gcloud artifacts repositories create --location=us-central1 --repository-format=Docker templates
+  _REPOSITORY_NAME: templates
+  _REPOSITORY_REGION: us-central1
+
+  _TEMPLATE_LAUNCHER_BASE_NAME: custom_template_launcher
+  _DISTROLESS_SUFFIX: distroless
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    script: |
+      docker build \
+        -t ${_REPOSITORY_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY_NAME}/${_TEMPLATE_LAUNCHER_BASE_NAME}:latest \
+        .
+    automapSubstitutions: true
+    id: base
+
+  - name: gcr.io/cloud-builders/docker
+    script: |
+      docker build \
+        -t ${_REPOSITORY_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY_NAME}/${_TEMPLATE_LAUNCHER_BASE_NAME}_${_DISTROLESS_SUFFIX}:latest \
+        -f Dockerfile-distroless \
+        --build-arg=BASE=${_REPOSITORY_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY_NAME}/${_TEMPLATE_LAUNCHER_BASE_NAME}:latest \
+        .
+    automapSubstitutions: true
+    wait_for: ['base']
+images:
+  - '${_REPOSITORY_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY_NAME}/${_TEMPLATE_LAUNCHER_BASE_NAME}:latest'
+  - '${_REPOSITORY_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY_NAME}/${_TEMPLATE_LAUNCHER_BASE_NAME}_${_DISTROLESS_SUFFIX}:latest'


### PR DESCRIPTION
This defines a container image variant for the Dataflow template launcher.

When launched on Dataflow, we see the log: 
![image](https://github.com/user-attachments/assets/89697904-ff78-433c-ae31-2d894f7c3b71), validating that it was pulling the image. And, the Job succeeded:

![image](https://github.com/user-attachments/assets/6ebc9724-301d-4049-9688-5b1176a155ec)

Without using the Distroless base, the base image had ~1,100 vulnerabilities. Using the Distroless base, reduced that down to <30.
